### PR TITLE
Revert to Account Kit version 5.0.1

### DIFF
--- a/src/platforms/ios/Podfile
+++ b/src/platforms/ios/Podfile
@@ -1,1 +1,1 @@
-pod 'AccountKit'
+pod 'AccountKit', '5.0.1'


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [X] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [X] Tests for the changes are included

## What is the current behavior?
Podfile downloads and installs iOS SDK Version 5.3.0, which breaks the plugin. (Unrecognized selector sent to instance)

## What is the new behavior?
Temporarily forcing to use 5.0.1 until the plugin is fully updated.


